### PR TITLE
Hysteresis + Sensor offset

### DIFF
--- a/fancontrol/TPFanControl.ini
+++ b/fancontrol/TPFanControl.ini
@@ -256,28 +256,34 @@ ShowAll=0
 // profile "Smart Mode 1"
 // change values and number of items for your needs
 // Celsius: // Fahrenheit:
+//
+// Furthermore, the hysteresis values are supported. 
+// Level=temp fan hystUp hystDown
+// For example: No hysteresis when temp rises, but 5c when cooling before switching to this level.
+//      Fan will not switch to this level until 55c
+// Level=60 0 0 5
 MenuLabelSM1=Smart Mode 1/ Label for Icon Menu, must be terminated by '/'
-// Level=60 0 // Level=140 0
-// Level=65 1 // Level=150 1
-// Level=75 3 // Level=165 3
-// Level=80 7 // Level=175 7
-// Level=90 64 // Level=195 64
-Level=50 0 // Level2=70 0
-Level=60 1 // Level2=90 1
-Level=70 2 // Level2=100 2
-Level=80 4 // Level2=110 3
-Level=90 7 // Level2=130 7
+// Level=60 0 0 0 // Level=140 0 0 0
+// Level=65 1 0 0 // Level=150 1 0 0
+// Level=75 3 0 0 // Level=165 3 0 0
+// Level=80 7 0 0 // Level=175 7 0 0
+// Level=90 64 0 0 // Level=195 64 0 0
+Level=50 0 0 0 // Level2=70 0 0 0
+Level=60 1 0 0 // Level2=90 1 0 0
+Level=70 2 0 0 // Level2=100 2 0 0
+Level=80 4 0 0 // Level2=110 3 0 0
+Level=90 7 0 0 // Level2=130 7 0 0
 // optional 2nd profile "Smart Mode 2", switched by icon menue
 // change values and number of items for your needs
 // to deactivate, insert leading '//' into following lines
 // MenuLabelSM2=Smart Mode 2/ Label for Icon Menu, must be terminated by '/'
-// Level2=22 0 // Level2=70 0
-// Level2=33 1 // Level2=90 1
-// Level2=38 2 // Level2=100 2
-// Level2=44 3 // Level2=110 3
-// Level2=55 7 // Level2=130 7
-// Level2=66 64 // Level2=150 64
-// Level2=77 128 // Level2=170 128
+// Level2=22 0 0 0 // Level2=70 0 0 0
+// Level2=33 1 0 0 // Level2=90 1 0 0
+// Level2=38 2 0 0 // Level2=100 2 0 0
+// Level2=44 3 0 0 // Level2=110 3 0 0
+// Level2=55 7 0 0 // Level2=130 7 0 0
+// Level2=66 64 0 0 // Level2=150 64 0 0
+// Level2=77 128 0 0 // Level2=170 128 0 0
 // -----------------------------------------------------------------
 // IconColorFan=1 digital Icon will turn green while fan is running.
 // IconColorFan=1 Digitales Icon wird grün während der Lüfter läuft.

--- a/fancontrol/TPFanControl.ini
+++ b/fancontrol/TPFanControl.ini
@@ -187,23 +187,27 @@ SensorName5=no5
 // Default SensorOffset1-12=0 , Capital O in SensorOffset,
 // to activate delete slashes '//',
 // Negative SensorOffsetno. values increase temperature values.
+// For applicable ranges: Specify a range (inclusive) where the offset is DISABLED if temperature is within this range
+// In format: SensorOffsetX=offset min max
+// For example: I want SensorOffset2 to apply only below 71c: SensorOffset2=20 -1 71
+//      (no value specified for min, upper limit is 71)
 // Berechnung von Highest Temp mit:
 // Temperatur des Sensor Nr. = reale Temp minus SensorOffsetnr.
 // Default: SensorOffset1-12=0 , Grosses O in SensorOffsetnr.
 // zum Aktivieren Schrägstriche '//' löschen,
 // Negative SensorOffsetnr-Werte erhöhen den Temperaturwert.
-//SensorOffset1=20
-//SensorOffset2=20
-//SensorOffset3=0
-//SensorOffset4=2
-//SensorOffset5=1
-//SensorOffset6=5
-//SensorOffset7=5
-//SensorOffset8=4
-//SensorOffset9=3
-//SensorOffset10=2
-//SensorOffset11=1
-//SensorOffset12=5
+//SensorOffset1=20 -1 -1
+//SensorOffset2=20 -1 -1
+//SensorOffset3=0 -1 -1
+//SensorOffset4=2 -1 -1
+//SensorOffset5=1 -1 -1
+//SensorOffset6=5 -1 -1
+//SensorOffset7=5 -1 -1
+//SensorOffset8=4 -1 -1
+//SensorOffset9=3 -1 -1
+//SensorOffset10=2 -1 -1
+//SensorOffset11=1 -1 -1
+//SensorOffset12=5 -1 -1
 // -----------------------------------------------------------------
 // set to 1 to show calculated temps for sensors
 // =1 gesetzt zeigt die Temperaturen mit Offsetkorrektur an

--- a/fancontrol/fancontrol.h
+++ b/fancontrol/fancontrol.h
@@ -88,12 +88,14 @@ protected:
 		int ftemp, ffan;
 	} FSmartLevels[32];
 
+	struct SENSOROFFSET {
+		int offs, hystMin, hystMax; // min and max temp values that offs takes effect. -1 to disable
+	} SensorOffset[16];
 
 	int IconLevels[3];    // temp levels for coloring the icon
 	int FIconLevels[3];    // fahrenheit temp levels for coloring the icon
 	int CurrentIcon;
 	int IndSmartLevel;
-	int SensorOffset[16];
 	int FSensorOffset[16];
 	int iFarbeIconB;
 	int iFontIconB;

--- a/fancontrol/fancontrol.h
+++ b/fancontrol/fancontrol.h
@@ -73,15 +73,15 @@ protected:
 	} State;
 
 	struct SMARTENTRY {
-		int temp, fan;
+		int temp, fan, hystUp, hystDown;
 	} SmartLevels[32];
 
 	struct SMARTENTRY1 {
-		int temp1, fan1;
+		int temp1, fan1, hystUp1, hystDown1;
 	} SmartLevels1[32];
 
 	struct SMARTENTRY2 {
-		int temp2, fan2;
+		int temp2, fan2, hystUp2, hystDown2;
 	} SmartLevels2[32];
 
 	struct FSMARTENTRY {        //fahrenheit values
@@ -91,7 +91,7 @@ protected:
 	struct SENSOROFFSET {
 		int offs, hystMin, hystMax; // min and max temp values that offs takes effect. -1 to disable
 	} SensorOffset[16];
-
+	int LastSmartLevel = -1;
 	int IconLevels[3];    // temp levels for coloring the icon
 	int FIconLevels[3];    // fahrenheit temp levels for coloring the icon
 	int CurrentIcon;

--- a/fancontrol/fanstuff.cpp
+++ b/fancontrol/fanstuff.cpp
@@ -62,7 +62,12 @@ FANCONTROL::HandleData(void) {
 
 		if (this->State.Sensors[i] != 0x80 && this - State.Sensors[i] != 0x00 && strstr(list, what) == 0) {
 			int isens = this->State.Sensors[i];
-			int ioffs = this->SensorOffset[i];
+			int ioffs = this->SensorOffset[i].offs;
+
+			// apply offset if in temp range
+			int calcTemp = isens - SensorOffset[i].offs;
+			if (isens >= SensorOffset[i].hystMin && isens <= SensorOffset[i].hystMax)
+				ioffs = 0;
 
 			if (ShowBiasedTemps)
 				senstemp = isens;
@@ -648,7 +653,7 @@ FANCONTROL::ReadEcRaw(FCSTATE* pfcstate) {
 		for (i = 0; i < 8 && ok; i++) {    // temp sensors 0x78 - 0x7f
 			ok = ReadByteFromEC(TP_ECOFFSET_TEMP0 + i, &pfcstate->Sensors[idxtemp]);
 			if (this->ShowBiasedTemps)
-				pfcstate->Sensors[idxtemp] = pfcstate->Sensors[idxtemp] - this->SensorOffset[idxtemp];
+				pfcstate->Sensors[idxtemp] = pfcstate->Sensors[idxtemp] - this->SensorOffset[idxtemp].offs;
 			if (!ok) {
 				this->Trace("failed to read TEMP0 byte from EC");
 			}
@@ -664,7 +669,7 @@ FANCONTROL::ReadEcRaw(FCSTATE* pfcstate) {
 				pfcstate->SensorName[idxtemp] = this->gSensorNames[idxtemp];
 				ok = ReadByteFromEC(TP_ECOFFSET_TEMP1 + i, &pfcstate->Sensors[idxtemp]);
 				if (this->ShowBiasedTemps)
-					pfcstate->Sensors[idxtemp] = pfcstate->Sensors[idxtemp] - this->SensorOffset[idxtemp];
+					pfcstate->Sensors[idxtemp] = pfcstate->Sensors[idxtemp] - this->SensorOffset[idxtemp].offs;
 				if (!ok) {
 					this->Trace("failed to read TEMP1 byte from EC");
 				}

--- a/fancontrol/misc.cpp
+++ b/fancontrol/misc.cpp
@@ -368,53 +368,53 @@ FANCONTROL::ReadConfig(const char* configfile)
 			// Read SensorOffsets
 																																																											else
 																																																												if (_strnicmp(buf, "SensorOffset1=", 14) == 0)
-																																																													this->SensorOffset[0] = atoi(buf + 14);
+																																																													sscanf_s(buf + 14, "%d %d %d", &this->SensorOffset[0].offs, &this->SensorOffset[0].hystMin, &this->SensorOffset[0].hystMax);
 																																																												else
 																																																													if (_strnicmp(buf, "SensorOffset2=", 14) == 0)
-																																																														this->SensorOffset[1] = atoi(buf + 14);
+																																																														sscanf_s(buf + 14, "%d %d %d", &this->SensorOffset[1].offs, &this->SensorOffset[1].hystMin, &this->SensorOffset[1].hystMax);
 																																																													else
 																																																														if (_strnicmp(buf, "SensorOffset3=", 14) == 0)
-																																																															this->SensorOffset[2] = atoi(buf + 14);
+																																																															sscanf_s(buf + 14, "%d %d %d", &this->SensorOffset[2].offs, &this->SensorOffset[2].hystMin, &this->SensorOffset[2].hystMax);
 																																																														else
 																																																															if (_strnicmp(buf, "SensorOffset4=", 14) == 0)
-																																																																this->SensorOffset[3] = atoi(buf + 14);
+																																																																sscanf_s(buf + 14, "%d %d %d", &this->SensorOffset[3].offs, &this->SensorOffset[3].hystMin, &this->SensorOffset[3].hystMax);
 																																																															else
 																																																																if (_strnicmp(buf, "SensorOffset5=", 14) == 0)
-																																																																	this->SensorOffset[4] = atoi(buf + 14);
+																																																																	sscanf_s(buf + 14, "%d %d %d", &this->SensorOffset[4].offs, &this->SensorOffset[4].hystMin, &this->SensorOffset[4].hystMax);
 																																																																else
 																																																																	if (_strnicmp(buf, "SensorOffset6=", 14) == 0)
-																																																																		this->SensorOffset[5] = atoi(buf + 14);
+																																																																		sscanf_s(buf + 14, "%d %d %d", &this->SensorOffset[5].offs, &this->SensorOffset[5].hystMin, &this->SensorOffset[5].hystMax);
 																																																																	else
 																																																																		if (_strnicmp(buf, "SensorOffset7=", 14) == 0)
-																																																																			this->SensorOffset[6] = atoi(buf + 14);
+																																																																			sscanf_s(buf + 14, "%d %d %d", &this->SensorOffset[6].offs, &this->SensorOffset[6].hystMin, &this->SensorOffset[6].hystMax);
 																																																																		else
 																																																																			if (_strnicmp(buf, "SensorOffset8=", 14) == 0)
-																																																																				this->SensorOffset[7] = atoi(buf + 14);
+																																																																				sscanf_s(buf + 14, "%d %d %d", &this->SensorOffset[7].offs, &this->SensorOffset[7].hystMin, &this->SensorOffset[7].hystMax);
 																																																																			else
 																																																																				if (_strnicmp(buf, "SensorOffset9=", 14) == 0)
-																																																																					this->SensorOffset[8] = atoi(buf + 14);
+																																																																					sscanf_s(buf + 14, "%d %d %d", &this->SensorOffset[8].offs, &this->SensorOffset[8].hystMin, &this->SensorOffset[8].hystMax);
 																																																																				else
 																																																																					if (_strnicmp(buf, "SensorOffset10=", 15) == 0)
-																																																																						this->SensorOffset[9] = atoi(buf + 15);
+																																																																						sscanf_s(buf + 14, "%d %d %d", &this->SensorOffset[9].offs, &this->SensorOffset[9].hystMin, &this->SensorOffset[9].hystMax);
 																																																																					else
 																																																																						if (_strnicmp(buf, "SensorOffset11=", 15) == 0)
-																																																																							this->SensorOffset[10] = atoi(buf + 15);
+																																																																							sscanf_s(buf + 15, "%d %d %d", &this->SensorOffset[10].offs, &this->SensorOffset[10].hystMin, &this->SensorOffset[10].hystMax);
 																																																																						else
 																																																																							if (_strnicmp(buf, "SensorOffset12=", 15) == 0)
-																																																																								this->SensorOffset[11] = atoi(buf + 15);
+																																																																								sscanf_s(buf + 15, "%d %d %d", &this->SensorOffset[11].offs, &this->SensorOffset[11].hystMin, &this->SensorOffset[11].hystMax);
 																																																																							else
 																																																																								if (_strnicmp(buf, "SensorOffset13=", 15) == 0)
-																																																																									this->SensorOffset[12] = atoi(buf + 15);
+																																																																									sscanf_s(buf + 15, "%d %d %d", &this->SensorOffset[12].offs, &this->SensorOffset[12].hystMin, &this->SensorOffset[12].hystMax);
 																																																																								else
 																																																																									if (_strnicmp(buf, "SensorOffset14=", 15) == 0)
-																																																																										this->SensorOffset[13] = atoi(buf + 15);
+																																																																										sscanf_s(buf + 15, "%d %d %d", &this->SensorOffset[13].offs, &this->SensorOffset[13].hystMin, &this->SensorOffset[13].hystMax);
 																																																																									else
 																																																																										if (_strnicmp(buf, "SensorOffset15=", 15) == 0)
-																																																																											this->SensorOffset[14] = atoi(buf + 15);
+																																																																											sscanf_s(buf + 15, "%d %d %d", &this->SensorOffset[14].offs, &this->SensorOffset[14].hystMin, &this->SensorOffset[14].hystMax);
 																																																																										else
 																																																																											if (_strnicmp(buf, "SensorOffset16=", 15) == 0)
-																																																																												this->SensorOffset[15] = atoi(buf + 15);
-
+																																																																												sscanf_s(buf + 15, "%d %d %d", &this->SensorOffset[15].offs, &this->SensorOffset[15].hystMin, &this->SensorOffset[15].hystMax);
+																																																																											
 			// End of Reading Sensor Offsets
 
 																																																																											else
@@ -581,19 +581,19 @@ FANCONTROL::ReadConfig(const char* configfile)
 
 	if (Fahrenheit) {
 		sprintf_s(buf, sizeof(buf), "  SensorOffset1-12= %d %d %d %d %d %d %d %d %d %d %d %d ° F",
-			this->SensorOffset[0], this->SensorOffset[1], this->SensorOffset[2],
-			this->SensorOffset[3], this->SensorOffset[4], this->SensorOffset[5],
-			this->SensorOffset[6], this->SensorOffset[7], this->SensorOffset[8],
-			this->SensorOffset[9], this->SensorOffset[10], this->SensorOffset[11]);
+			this->SensorOffset[0].offs, this->SensorOffset[1].offs, this->SensorOffset[2].offs,
+			this->SensorOffset[3].offs, this->SensorOffset[4].offs, this->SensorOffset[5].offs,
+			this->SensorOffset[6].offs, this->SensorOffset[7].offs, this->SensorOffset[8].offs,
+			this->SensorOffset[9].offs, this->SensorOffset[10].offs, this->SensorOffset[11].offs);
 
-		for (i = 0; i < 15; i++) { SensorOffset[i] = SensorOffset[i] * 5 / 9; }
+		for (i = 0; i < 15; i++) { SensorOffset[i].offs = SensorOffset[i].offs * 5 / 9; }
 	}
 	else {
 		sprintf_s(buf, sizeof(buf), "  SensorOffset1-12= %d %d %d %d %d %d %d %d %d %d %d %d ° C",
-			this->SensorOffset[0], this->SensorOffset[1], this->SensorOffset[2],
-			this->SensorOffset[3], this->SensorOffset[4], this->SensorOffset[5],
-			this->SensorOffset[6], this->SensorOffset[7], this->SensorOffset[8],
-			this->SensorOffset[9], this->SensorOffset[10], this->SensorOffset[11]);
+			this->SensorOffset[0].offs, this->SensorOffset[1].offs, this->SensorOffset[2].offs,
+			this->SensorOffset[3].offs, this->SensorOffset[4].offs, this->SensorOffset[5].offs,
+			this->SensorOffset[6].offs, this->SensorOffset[7].offs, this->SensorOffset[8].offs,
+			this->SensorOffset[9].offs, this->SensorOffset[10].offs, this->SensorOffset[11].offs);
 	}
 
 	this->Trace(buf);

--- a/fancontrol/misc.cpp
+++ b/fancontrol/misc.cpp
@@ -131,13 +131,13 @@ FANCONTROL::ReadConfig(const char* configfile)
 														}
 														else
 															if (_strnicmp(buf, "level=", 6) == 0) {
-																sscanf_s(buf + 6, "%d %d", &this->SmartLevels[lcnt].temp, &this->SmartLevels[lcnt].fan);
-																sscanf_s(buf + 6, "%d %d", &this->SmartLevels1[lcnt].temp1, &this->SmartLevels1[lcnt].fan1);
+																sscanf_s(buf + 6, "%d %d %d %d", &this->SmartLevels[lcnt].temp, &this->SmartLevels[lcnt].fan, &this->SmartLevels[lcnt].hystUp, &this->SmartLevels[lcnt].hystDown);
+																sscanf_s(buf + 6, "%d %d %d %d", &this->SmartLevels1[lcnt].temp1, &this->SmartLevels1[lcnt].fan1, &this->SmartLevels1[lcnt].hystUp1, &this->SmartLevels1[lcnt].hystDown1);
 																lcnt++;
 															}
 															else
 																if (_strnicmp(buf, "level2=", 7) == 0) {
-																	sscanf_s(buf + 7, "%d %d", &this->SmartLevels2[lcnt2].temp2, &this->SmartLevels2[lcnt2].fan2);
+																	sscanf_s(buf + 7, "%d %d %d %d", &this->SmartLevels2[lcnt2].temp2, &this->SmartLevels2[lcnt2].fan2, &this->SmartLevels2[lcnt].hystUp2, &this->SmartLevels2[lcnt].hystDown2);
 																	lcnt2++;
 																}
 																else


### PR DESCRIPTION
Hi. A couple of features that help alleviate some annoyances with fan speeds changing too frequently. Both of these default to being disabled, however require configuration file updating nonetheless.


## Hysteresis configuration 
Config in ini:
`Level=temp fan hystUp hystDown`
For example: No hysteresis when temp rises, but 5c when cooling before switching to this level. Fan will not switch to this level until 55c:
`Level=60 0 0 5`
- Maybe fixes #63

## Sensor offset range
- This mostly helps with edge cases such as 75c dGPU temp limits, where the CPU temp is too low to increase fan levels, but GPU has been long throttling

Sensor offset will apply within the specified temperature range
`SensorOffsetX=offset min max`
For example: I want SensorOffset2 to apply only below 71c:
`SensorOffset2=20 -1 71` (no value specified for min, upper limit is 71)



Tested on Windows 10, X1 Extreme 2nd, 