### PR TITLE
[Fix] Dual fan speed display shows Fan2 twice

### DIFF
--- a/fancontrol/fanstuff.cpp
+++ b/fancontrol/fanstuff.cpp
@@ -660,8 +660,6 @@ FANCONTROL::ReadEcRaw(FCSTATE* pfcstate) {
 		this->Trace("failed to read FanSpeedHighByte 2 from EC");
 	}
 
-	ok = ReadByteFromEC(TP_ECOFFSET_FAN, &pfcstate->FanCtrl);
-
 	ok = this->WriteByteToEC(TP_ECOFFSET_FAN_SWITCH, TP_ECOFFSET_FAN1);
 
 	if (ok)

--- a/fancontrol/fanstuff.cpp
+++ b/fancontrol/fanstuff.cpp
@@ -660,6 +660,10 @@ FANCONTROL::ReadEcRaw(FCSTATE* pfcstate) {
 		this->Trace("failed to read FanSpeedHighByte 2 from EC");
 	}
 
+	ok = ReadByteFromEC(TP_ECOFFSET_FAN, &pfcstate->FanCtrl);
+
+	ok = this->WriteByteToEC(TP_ECOFFSET_FAN_SWITCH, TP_ECOFFSET_FAN1);
+
 	if (ok)
 		ok = ReadByteFromEC(TP_ECOFFSET_FANSPEED, &pfcstate->FanSpeedLo1);
 	if (!ok) {


### PR DESCRIPTION
Both speeds were shown as the same (both were Fan2).

![image](https://github.com/user-attachments/assets/7b327c19-314b-4f97-a1da-c066ce5e5e03)

With this change, Fan1 **and** Fan2 speeds are shown

![image](https://github.com/user-attachments/assets/6bff58d7-2e2f-4319-82c2-e24143e1f1e4)
