### PR TITLE
Replace hardcoded 75 by parameter ManModeExit

### DIFF
--- a/fancontrol/fanstuff.cpp
+++ b/fancontrol/fanstuff.cpp
@@ -323,7 +323,7 @@ FANCONTROL::HandleData(void) {
 	}
 
 	this->PreviousMode = this->CurrentMode;
-	if (this->CurrentMode == 3 && this->MaxTemp > 75) this->CurrentMode = 2; //hello
+	if (this->CurrentMode == 3 && this->MaxTemp > ManModeExit2) this->CurrentMode = 2; //hello
 
 	return ok;
 }


### PR DESCRIPTION
The parameter "ManModeExit" was being ignored. Instead, a hardcoded value of 75 was being used.